### PR TITLE
Accept environment variables as alternative to command-line arguments for substitutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ Once you have a template file you can pass in values for variables defined in th
 
     0template my-app.xml.template version=1.0
 
-This will cause 0template to create a new file named `my-app-1.0.xml` with any occurences of `{version}` substituted with `1.0` and `<manifest-digest>`s calculated.
+Alternatively you can also use environment variables instead of command-line arguments to pass in values for variables defined in the template:
 
-You can also let 0template generate an archive from a local directory by adding something like this to your template:
+    version=1.0 0template my-app.xml.template
+
+Both options will cause 0template to create a new file named `my-app-1.0.xml` with any occurences of `{version}` substituted with `1.0` and `<manifest-digest>`s calculated.
+
+You can let 0template generate an archive from a local directory by adding something like this to your template:
 ```xml
 <implementation local-path="directory/to/pack/in/archive">
   <manifest-digest />

--- a/expand.py
+++ b/expand.py
@@ -1,6 +1,7 @@
 from xml.dom import minidom, Node
 import argparse
 import sys
+import os
 import string
 
 from __main__ import die
@@ -14,8 +15,15 @@ class UsedDict:
 	
 	def __getitem__(self, key):
 		assert key != 'foo'
-		self.used.add(key)
-		return self.underlying[key]
+		if key in self.underlying:
+			self.used.add(key)
+			return self.underlying[key]
+		else:
+			value = os.getenv(key)
+			if value is None:
+				die("Missing value for '{key}'".format(key = key))
+			else:
+				return value
 
 	def keys(self):
 		return self.underlying.keys()
@@ -28,11 +36,7 @@ def process_doc(doc, env):
 
 	# Expand the template strings with the command-line arguments
 	def expand(template_string):
-		try:
-			return formatter.vformat(template_string, [], wrapped_env)
-		except KeyError as ex:
-			die("Missing value for {name} in '{template}'".format(
-				name = str(ex), template = template_string))
+		return formatter.vformat(template_string, [], wrapped_env)	
 
 	def process(elem):
 		for name, value in elem.attributes.items():


### PR DESCRIPTION
This is useful for passing in complicated values on Windows, where command-line argument escaping rules are a little bit tricky.