### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Prepare
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: gittools/actions/gitversion/setup@v0.9.15
+        with:
+          versionSpec: '5.12.x'
+      - uses: gittools/actions/gitversion/execute@v0.9.15
+        id: gitversion
+
+      # Build
+      - name: Inject version number
+        run: sed -i "s/^version = '.*'$/version = '${{steps.gitversion.outputs.legacySemVer}}'/" 0template.py
+      - name: 0test
+        run: ./0install.sh run https://apps.0install.net/0install/0test.xml 0template.xml
+      - name: 0template
+        run: ./0install.sh run https://apps.0install.net/0install/0template.xml 0template.xml.template version=${{steps.gitversion.outputs.legacySemVer}}
+
+      # Release
+      - name: Create GitHub Release
+        if: steps.gitversion.outputs.preReleaseLabel == ''
+        uses: softprops/action-gh-release@v1
+        with:
+          files: 0template-${{steps.gitversion.outputs.legacySemVer}}.*
+      - name: Publish feed
+        if: steps.gitversion.outputs.preReleaseLabel == ''
+        env:
+          GH_TOKEN: ${{secrets.PERSONAL_TOKEN}}
+        run: >
+          gh workflow run --repo=0install/apps Incoming
+          -f feed_url=https://github.com/${{github.repository}}/releases/download/${{steps.gitversion.outputs.legacySemVer}}/0template-${{steps.gitversion.outputs.legacySemVer}}.xml
+          -f archive_url=https://github.com/${{github.repository}}/releases/download/${{steps.gitversion.outputs.legacySemVer}}/0template-${{steps.gitversion.outputs.legacySemVer}}.tar.bz2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Caches
 __pycache__/
 *.py[cod]
 .idea/
+
+# Output
+/0template-*.xml
+/0template-*.tar.bz2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: c
-dist: trusty
-sudo: required
-services:
-  - docker
-script:
-  - docker run --rm -it -v $(pwd):/mnt talex5/0install 0test /mnt/0template.xml

--- a/0install.sh
+++ b/0install.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -e
+
+if [ "$#" -eq 0 ]; then
+    echo "This script runs 0install from your PATH or downloads it on-demand."
+    echo ""
+    echo "To run 0install commands without adding 0install to your PATH:"
+    echo "./0install.sh --help"
+    echo "./0install.sh COMMAND [OPTIONS]"
+    echo ""
+    echo "To install to /usr/local:"
+    echo "sudo ./0install.sh install local"
+    echo ""
+    echo "To install to your home directory:"
+    echo "./0install.sh install home"
+    exit 1
+fi
+
+download() {
+    zeroinstall_release=0install-$(uname | tr '[:upper:]' '[:lower:]')-$(uname -m)-${ZEROINSTALL_VERSION:-latest}
+    download_dir=~/.cache/0install.net/$zeroinstall_release
+
+    if [ ! -f $download_dir/files/0install ]; then
+        echo "Downloading 0install..." >&2
+        rm -rf $download_dir
+        mkdir -p $download_dir
+        curl -sSL https://get.0install.net/$zeroinstall_release.tar.bz2 | tar xj --strip-components 1 --directory $download_dir
+    fi
+}
+
+if [ "$1" = "install" ]; then
+    download
+    shift 1
+    $download_dir/install.sh "$@"
+else
+    if command -v 0install > /dev/null 2> /dev/null; then
+        0install "$@"
+    else
+        download
+        $download_dir/files/0install "$@"
+    fi
+fi

--- a/0template.py
+++ b/0template.py
@@ -22,7 +22,7 @@ import expand
 import retrieval
 import digest
 
-version = '0.9'
+version = 'git-checkout'
 
 config = load_config()
 

--- a/0template.xml.template
+++ b/0template.xml.template
@@ -31,7 +31,9 @@
       <executable-in-var command="0publish" name="0TEMPLATE_EXTERNAL_TOOL"/>
     </requires>
 
-    <!-- Use very high version number to treat local build as newer than any public version. -->
-    <implementation id="local" version="100-pre" stability="developer" local-path="."/>
+    <implementation version="{version}" local-path=".">
+      <manifest-digest/>
+      <archive href="0watch-{version}.tar.bz2"/>
+    </implementation>
   </group>
 </interface>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,22 @@
+mode: ContinuousDeployment
+
+# Generate 0install-compatible version numbers
+branches:
+  # Stabilization branches
+  release:
+    tag: rc
+  hotfix:
+    tag: rc
+
+  # Mainline branches
+  master: 
+    tag: rc-pre
+  develop:
+    tag: pre
+    increment: patch
+
+  # Topic branches
+  feature:
+    tag: pre-pre
+  pull-request:
+    tag: pre-pre


### PR DESCRIPTION
- Replace Travis CI with GitHub Actions
- Replace `0release` with `0template`
- Automatically publish release on Git tag

When a new Git tag is pushed to the repository, the GitHub pipeline will do the following:
1. Determine the version number from Git tag and `sed` it into the code
2. Run `0test`
3. Run `0template` to generate `0template-1.2.3.xml` and `0template-1.2.3.tar.gz`
4. Create a GitHub Release with `0template-1.2.3.xml` and `0template-1.2.3.tar.gz` as artifacts
5. Trigger another GitHub pipeline in the [0install/apps](https://github.com/0install/apps) repo, passing the URLs of  `0template-1.2.3.xml` and `0template-1.2.3.tar.gz` as inputs
   - This pipeline adds `0template-1.2.3.tar.gz` to `archives.db` and `0template-1.2.3.xml` to `0template.xml`